### PR TITLE
use console instead of sh

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,16 +9,16 @@ and pip >= 21.3 to
  - support self resolving dependencies
  - editable installs pyproject.toml
 
-```sh
-python3 -m venv .venv
-. .venv/bin/activate
-python -m pip install --upgrade 'pip>=21.3'
-python -m pip install --editable '.[dev]'
+```console
+$ python3 -m venv .venv
+$ . .venv/bin/activate
+$ python -m pip install --upgrade 'pip>=21.3'
+$ python -m pip install --editable '.[dev]'
 ```
 
 Then verify by running the tests
 
-```sh
+```console
 $ pytest -qq
 ..                                   [100%]
 ```


### PR DESCRIPTION
console is intended to syntax highlight the output of shell session